### PR TITLE
Add 'Auto Collapse AutoModerator Comment' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ I welcome any help if you would like to improve or contribute new language trans
 |Show Post Author on the Home Feed|Shows the missing post author on the home feed for New New UI.|"New New"|
 |Show Post Flair on the Home Feed|Shows the missing post flair on the home feed for New New UI.|"New New"|
 |Always Show Post Options|Moves the items in the post overflow menu into the header bar for quicker access.|"New New"|
+|Auto Collapse AutoModerator Comment|Automatically collapses the top comment made by AutoModerator|"All"|
 
 ## Build
 Clone repo and cd to build directory:

--- a/src-webpack/src/common/_locales/en/messages.json
+++ b/src-webpack/src/common/_locales/en/messages.json
@@ -755,6 +755,10 @@
 		"message": "Auto Expand Comments"
 	},
 
+	"AutoCollapseAutoModeratorComment": {
+		"message": "Auto Collapse AutoModerator Comment"
+	},
+
 	"AutoExpandCommentsInfo": {
 		"message": "May cause the page to initially lag, especially if there are a lot of comments."
 	},

--- a/src-webpack/src/common/content-first/functions/productivity/load_auto_collapse_automod_comment.js
+++ b/src-webpack/src/common/content-first/functions/productivity/load_auto_collapse_automod_comment.js
@@ -1,0 +1,9 @@
+// Auto Collapse AutoModerator Comment
+
+import { autoCollapseAutoModeratorComment } from '../../../content/functions/productivity/auto_collapse_automod_comment';
+
+export function loadAutoCollapseAutoModeratorComment() {
+	BROWSER_API.storage.sync.get(['autoCollapseAutoModeratorComment'], function (result) {
+		autoCollapseAutoModeratorComment(result.autoCollapseAutoModeratorComment);
+	});
+}

--- a/src-webpack/src/common/content/content_load_saves.js
+++ b/src-webpack/src/common/content/content_load_saves.js
@@ -27,6 +27,7 @@ import { loadShowPostNumbers } from '../content-first/functions/productivity/loa
 import { loadBreakReminder } from '../content-first/functions/productivity/load_break_reminder';
 import { loadAutoExpandComments } from '../content-first/functions/productivity/load_auto_expand_comments';
 import { showPostFlair } from './functions/productivity/show_post_flair';
+import { autoCollapseAutoModeratorComment } from "./functions/productivity/auto_collapse_automod_comment";
 //import { addDownloadVideoButton } from './functions/productivity/add_download_video_button';
 
 export function load_saves() {
@@ -147,6 +148,10 @@ export function load_saves() {
 	// Feed Auto Expand
 	BROWSER_API.storage.sync.get(['autoExpandValue'], function (result) {
 		autoExpandValue(result.autoExpandValue);
+	});
+	// Auto Collapse AutoModerator Comment
+	BROWSER_API.storage.sync.get(['autoCollapseAutoModeratorComment'], function (result) {
+		autoCollapseAutoModeratorComment(result.autoCollapseAutoModeratorComment);
 	});
 
 	// Run again

--- a/src-webpack/src/common/content/functions/productivity/auto_collapse_automod_comment.js
+++ b/src-webpack/src/common/content/functions/productivity/auto_collapse_automod_comment.js
@@ -1,0 +1,28 @@
+// Auto Collapse AutoModerator Comment
+
+export function autoCollapseAutoModeratorComment(value) {
+	if (redditVersion === 'old' && value === true) {
+    autoCollapseAutoModeratorCommentOld();
+  } else if (redditVersion === 'new' && value === true) {
+		setTimeout(() => {
+      autoCollapseAutoModeratorCommentNew();
+		}, 1000);
+  } else if (redditVersion === 'newnew' && value === true) {
+    autoCollapseAutoModeratorCommentNewNew();
+  }
+}
+
+// Function - Auto Collapse AutoModerator Comment - Old
+function autoCollapseAutoModeratorCommentOld() {
+  document.querySelector('.comment[data-author="AutoModerator"]').classList.add('collapsed');
+}
+
+// Function - Auto Collapse AutoModerator Comment - New
+function autoCollapseAutoModeratorCommentNew() {
+  document.querySelector(".Comment [href='/user/AutoModerator/']").parentElement.parentElement.previousSibling.click();
+}
+
+// Function - Auto Collapse AutoModerator Comment - New New
+function autoCollapseAutoModeratorCommentNewNew() {
+  document.querySelector('shreddit-comment[author="AutoModerator"]').setAttribute('collapsed', 'true');
+}

--- a/src-webpack/src/common/content/popup_listener.js
+++ b/src-webpack/src/common/content/popup_listener.js
@@ -112,6 +112,7 @@ import { hidePostHiddenMessage } from './functions/hide_elements/hide_post_hidde
 import { showPostFlair } from './functions/productivity/show_post_flair';
 //import { scalePostToFitImageMaxImageWidth, scalePostToFitImage } from './functions/productivity/scale_post_to_fit_image';
 //import { dragImageToResize, dragImageToResizeInitialSize } from './functions/productivity/scale_image_on_drag';
+import { autoCollapseAutoModeratorComment } from './functions/productivity/auto_collapse_automod_comment';
 
 /* = Listen For Settings Change = */
 BROWSER_API.runtime.onMessage.addListener((msg, sender, response) => {
@@ -396,7 +397,9 @@ BROWSER_API.runtime.onMessage.addListener((msg, sender, response) => {
 		dragImageToResizeInitialSize(value);
 	}*/ /* else if (key == 'addDownloadVideoButton') {
 		addDownloadVideoButton(value);
-	}*/ else if (key == 'loadSaves') {
+	}*/ else if (key == 'autoCollapseAutoModeratorComment') {
+		autoCollapseAutoModeratorComment(value);
+	} else if (key == 'loadSaves') {
 		setTimeout(() => {
 			init();
 			load_saves();

--- a/src-webpack/src/common/popup/inputs/inputs_productivity.js
+++ b/src-webpack/src/common/popup/inputs/inputs_productivity.js
@@ -1141,3 +1141,30 @@ document.querySelector('#checkbox-auto-expand-comments').addEventListener('chang
 		});
 	}
 });*/
+
+// Toggle - Auto Collapse AutoModerator Comment
+document.querySelector('#checkbox-auto-collapse-automoderator-comment').addEventListener('change', function (e) {
+	const autoCollapseAutoModeratorComment = document.querySelector('#checkbox-auto-collapse-automoderator-comment').checked;
+	if (autoCollapseAutoModeratorComment === true) {
+		BROWSER_API.storage.sync.set({ autoCollapseAutoModeratorComment: true });
+		document.querySelector('.icon-auto-collapse-automoderator-comment').style.backgroundColor = 'var(--accent)';
+		BROWSER_API.tabs.query({ currentWindow: true }, function (tabs) {
+			tabs.forEach(function (tab) {
+				if (tab.url.match('https://.*.reddit.com/.*') && tab.discarded == false) {
+					BROWSER_API.tabs.sendMessage(tab.id, { autoCollapseAutoModeratorComment: true });
+				}
+			});
+		});
+	} else if (autoCollapseAutoModeratorComment === false) {
+		BROWSER_API.storage.sync.set({ autoCollapseAutoModeratorComment: false });
+		document.querySelector('.icon-auto-collapse-automoderator-comment').style.backgroundColor = '';
+		BROWSER_API.tabs.query({ currentWindow: true }, function (tabs) {
+			tabs.forEach(function (tab) {
+				if (tab.url.match('https://.*.reddit.com/.*') && tab.discarded == false) {
+					BROWSER_API.tabs.sendMessage(tab.id, { autoCollapseAutoModeratorComment: false });
+				}
+			});
+		});
+	}
+});
+

--- a/src-webpack/src/common/popup/popup-restore.js
+++ b/src-webpack/src/common/popup/popup-restore.js
@@ -2343,6 +2343,20 @@ function restoreOptions() {
 		}
 	});
 
+// Auto Collapse AutoModerator Comment
+	BROWSER_API.storage.sync.get(['autoCollapseAutoModeratorComment'], function (result) {
+		if (result.autoCollapseAutoModeratorComment == true) {
+			document.querySelector('.icon-auto-collapse-automoderator-comment').style.backgroundColor = 'var(--accent)';
+			document.querySelector('#checkbox-auto-collapse-automoderator-comment').checked = true;
+			document.querySelector('.icon-productivity-tweaks').style.backgroundColor = 'var(--accent)';
+			var value = true;
+		} else if (typeof result.autoCollapseAutoModeratorComment== 'undefined' || result.autoCollapseAutoModeratorComment == false) {
+			document.querySelector('#checkbox-auto-collapse-automoderator-comment').checked = false;
+			var value = false;
+		}
+		console.log('Auto Collapse AutoModerator Comment: ' + value);
+	});
+
 	// Add Download Video Button
 	/*BROWSER_API.storage.sync.get(['addDownloadVideoButton'], function (result) {
 		if (result.addDownloadVideoButton == true) {

--- a/src-webpack/src/common/popup/popup.html
+++ b/src-webpack/src/common/popup/popup.html
@@ -898,6 +898,14 @@
 						<div></div>
 						<p data-lang="AutoExpandCommentsInfo"></p>
 					</li>
+					<li class="container container-3 r-old r-new r-newnew">
+						<span class="menu-item-icon icon-scale icon-auto-collapse-automoderator-comment"></span>
+						<span data-lang="AutoCollapseAutoModeratorComment" data-search="pagination"></span>
+						<label class="switch">
+							<input id="checkbox-auto-collapse-automoderator-comment" type="checkbox" />
+							<span class="indicator"></span>
+						</label>
+					</li>
 					<li class="container container-3 r-new">
 						<span class="menu-item-icon icon-play icon-new-player"></span>
 						<span data-lang="VideoPlayerReplacement" data-search="video,player"></span>


### PR DESCRIPTION
This adds an option for all Reddit versions to automatically collapse the top comment made by AutoModerator. Not sure if there is a better implementation for the "Old New UI" as I had to use a `setTimeout` to wait for the button to load which is a bit hacky. 