### PR TITLE
[Old New UI] Resize h1 and code in comments, remove header in post overlay when Non-Sticky Header Bar is on

### DIFF
--- a/src-webpack/src/common/content/tweaks/font/resize_font.js
+++ b/src-webpack/src/common/content/tweaks/font/resize_font.js
@@ -137,10 +137,15 @@ export function postCommentsFontSize(value) {
 			if (!document.querySelector('style[id="re-post-comment-font-size"]')) {
 				const styleElement = document.createElement('style');
 				styleElement.id = 're-styles';
-				styleElement.textContent = `.Comment [data-testid="comment"] p {
+				styleElement.textContent = `.Comment [data-testid="comment"] > div,
+				 							.Comment [data-testid="comment"] > div code {
 												font-size: var(--re-post-comments-font-size);
-												line-height: 1.4;
+												line-height: 1.6;
 												overflow: hidden;
+											}
+											.Comment [data-testid="comment"] > div > div {
+												font-size: 1.5em;
+												line-height: inherit;
 											}`;
 				document.head.insertBefore(styleElement, document.head.firstChild);
 			}

--- a/src-webpack/src/common/content/tweaks/hide_elements/hide_header_bar.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/hide_header_bar.js
@@ -34,6 +34,12 @@ function hideHeaderBarNew() {
 		styleElement.textContent = `header {
 										display: none !important;
 									}
+									div#AppRouter-main-content {
+										padding-top: 0 !important;
+									}
+									div:has(> div#overlayScrollContainer) {
+										top: 0 !important;
+									}
 									#SHORTCUT_FOCUSABLE_DIV > div[class*="subredditvars-r"] > div {
 										top: 0;
 									}`;

--- a/src-webpack/src/common/content/tweaks/hide_elements/hide_sidebar.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/hide_sidebar.js
@@ -385,6 +385,10 @@ function enableHidePostOverlaySidebarNew() {
 	styleElement.id = 're-hide-post-overlay-sidebar';
 	styleElement.textContent = `#overlayScrollContainer > :nth-child(2) > :last-child {
 									display: none !important;
+									
+									~ div {
+										margin: 1.25rem !important;
+									}
 								}`;
 	document.head.insertBefore(styleElement, document.head.firstChild);
 }

--- a/src-webpack/src/common/content/tweaks/productivity/non_sticky_header_bar.js
+++ b/src-webpack/src/common/content/tweaks/productivity/non_sticky_header_bar.js
@@ -33,6 +33,12 @@ function enableNonStickyHeaderBarNew() {
 								}
 								#SHORTCUT_FOCUSABLE_DIV > div[class*="subredditvars-r"] > div {
 									top: 0;
+								}
+								#SHORTCUT_FOCUSABLE_DIV:has(div#overlayScrollContainer) header {
+									display: none;
+								}
+								div:has(> div#overlayScrollContainer) {
+									top: 0;
 								}`;
 	document.head.insertBefore(styleElement, document.head.firstChild);
 }

--- a/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
@@ -227,11 +227,12 @@ function enableExpandContentNew() {
 									max-width: 100% !important;
 								}
 								#overlayScrollContainer > :first-child,
-								#overlayScrollContainer > :first-child > div,
 								#overlayScrollContainer > div:has(.Post) {
 									width: var(--re-post-overlay-width) !important;
 									max-width: var(--re-post-overlay-width) !important;
-										
+								}
+								#overlayScrollContainer > :first-child > div {
+									max-width: 100% !important;
 								}
 								#SHORTCUT_FOCUSABLE_DIV [class^="subredditvars-r-"] :first-child::after {
 									width: var(--re-post-overlay-width) !important;

--- a/src-webpack/src/common/content_first/functions/load_styles.js
+++ b/src-webpack/src/common/content_first/functions/load_styles.js
@@ -216,7 +216,7 @@ const styleOther = `.re-to-top-button:hover, .re-all-button:hover {
 						margin: 1rem 0;
 						padding: 0;
 					}
-					#overlayScrollContainer button.voteButton ~ div {
+					#overlayScrollContainer > :first-child button.voteButton ~ div {
 						padding: 0 0.5rem;
 					}`;
 

--- a/src-webpack/src/common/content_first/functions/tweak_loaders/legacy_observers.js
+++ b/src-webpack/src/common/content_first/functions/tweak_loaders/legacy_observers.js
@@ -228,7 +228,7 @@ export function observerFeedContainerAndFeed() {
 }
 
 // Feed Container
-export function observerFeedConainter() {
+export function observerFeedContainer() {
 	const link = window.location.href;
 	let page = '';
 	if (link.indexOf('/comments/') >= 0) {

--- a/src-webpack/src/common/content_first/functions/tweak_loaders/tweak_loader_oldnew.js
+++ b/src-webpack/src/common/content_first/functions/tweak_loaders/tweak_loader_oldnew.js
@@ -5,7 +5,7 @@
 
 //import { waitForAddedNode } from './main_observer';
 
-import { legacyObserversNew, observerFeedConainter, observerFeedContainerAndFeed, observerSearchContainer, observerSort, observerUserFeedContainerAndFeed, observerUserSidebar, observerUserSort } from './legacy_observers';
+import { legacyObserversNew, observerFeedContainer, observerFeedContainerAndFeed, observerSearchContainer, observerSort, observerUserFeedContainerAndFeed, observerUserSidebar, observerUserSort } from './legacy_observers';
 import { loadHideAdvertiseButton, loadHideChatButton, loadHideCreatePostButton, loadHideModerationButton, loadHideNotificationButton, loadHidePopularButton } from '../../../content/tweaks/hide_elements/hide_header_buttons';
 import { loadBionicReaderColours } from '../../../content/tweaks/accessibility/bionic_reader';
 import { loadCustomBackground } from '../../../content/tweaks/background/custom_background';
@@ -69,7 +69,7 @@ export function tweakLoaderOldNew() {
 		loadHideUserProfilePics();
 		if (useLegacy) {
 			console.log('legacy observers feed container');
-			observerFeedConainter();
+			observerFeedContainer();
 		} else {
 			loadHidePostSidebar();
 		}
@@ -90,10 +90,6 @@ export function tweakLoaderOldNew() {
 		if (useLegacy) {
 			observerSearchContainer();
 		}
-	} else if (/\/user\/[^\/]+\/m\//.test(link)) {
-		// custom feed
-		loadCommon();
-		loadHideCustomFeedSidebar();
 	} else {
 		// feed/sub
 		loadCommon();
@@ -115,6 +111,7 @@ export function tweakLoaderOldNew() {
 			loadHideSubSidebarException();
 			loadHidePostOverlaySidebar();
 			loadStickySort();
+			loadHideCustomFeedSidebar();
 		}
 	}
 }


### PR DESCRIPTION
```
* [Old New UI] Resizing fonts now works with h1 and code in comments
* [Old New UI] Removed the header bar and top padding in post overlays when Non-Sticky Header Bar is on
```

sorry!