### PR TITLE
New New UI: Disable Custom Background on subreddit mod pages & apply Post Background to Mod Queue

### DIFF
--- a/src-webpack/src/common/content/tweaks/background/custom_background.js
+++ b/src-webpack/src/common/content/tweaks/background/custom_background.js
@@ -123,10 +123,10 @@ function enableUseCustomBackgroundNewNew() {
 								shreddit-app[routename="profile_post_page"] div[slot="post-insights-panel"] .p-md {
 									padding: 0;
 								}
-								aside#mod-queue-pdp-panel {
-									background-color: var(--color-neutral-background);
+								shreddit-app div.sidebar-grid {
+									background-color: var(--color-neutral-background) !important;
+									max-width: unset;
 								}`;
-
 	document.head.insertBefore(styleElement, document.head.firstChild);
 }
 

--- a/src-webpack/src/common/content/tweaks/style/override_theme_colours.js
+++ b/src-webpack/src/common/content/tweaks/style/override_theme_colours.js
@@ -548,6 +548,9 @@ export function themePostBackgroundColour(value) {
 											--color-neutral-background-hover: color-mix(in srgb, var(--re-theme-post-bg), #000 10%) !important;
 											background-color: color-mix(in srgb, var(--re-theme-post-bg), #000 10%) !important;
 										}
+										shreddit-feed shreddit-post:focus-within {
+											--color-neutral-background-hover: var(--re-theme-post-bg);
+										}
 										div[slot="post-insights-panel"] > faceplate-tracker > div {
 											background-color: inherit !important;
 										}

--- a/src-webpack/src/common/content/tweaks/style/override_theme_colours.js
+++ b/src-webpack/src/common/content/tweaks/style/override_theme_colours.js
@@ -537,6 +537,13 @@ export function themePostBackgroundColour(value) {
 											--shreddit-content-background: transparent !important;
 											--color-neutral-background: var(--re-theme-post-bg) !important;
 										}
+										div[slot="mod-queue-feed"] {
+											--color-neutral-background: var(--re-theme-post-bg);
+											--color-neutral-background-weak: var(--re-theme-post-bg);
+										}
+										aside#mod-queue-pdp-panel {
+											background-color: var(--re-theme-post-bg);
+										}
 										shreddit-feed shreddit-post:hover {
 											--color-neutral-background-hover: color-mix(in srgb, var(--re-theme-post-bg), #000 10%) !important;
 											background-color: color-mix(in srgb, var(--re-theme-post-bg), #000 10%) !important;


### PR DESCRIPTION
* [New New UI] Disabled Custom Background on subreddit moderation pages as the background is incorrectly applied on the side menu. Reddit makes it very difficult to style moderation pages correctly, due to many things locked behind shadow DOMs.
* [New New UI] Post Background now applies to Compact posts in moderation queue