### PR TITLE
New New UI: bug fixes and small tweaks

### DIFF
--- a/src-webpack/src/common/content/tweaks/background/custom_background.js
+++ b/src-webpack/src/common/content/tweaks/background/custom_background.js
@@ -106,7 +106,8 @@ function enableUseCustomBackgroundNewNew() {
 								}
 								shreddit-app[routename="post_page"] main.main,
 								shreddit-app[routename="comments_page"] main.main,
-								shreddit-app[routename="profile_post_page"] main.main {
+								shreddit-app[routename="profile_post_page"] main.main,
+								shreddit-app[routename="post_stats"] main.main {
 									margin: 1rem 0;
 									padding: .75rem 1rem;
 									background-color: var(--re-theme-post-bg, var(--color-neutral-background, #000));
@@ -117,6 +118,9 @@ function enableUseCustomBackgroundNewNew() {
 										margin: 0;
 										padding: 0;
 									}
+								}
+								shreddit-app[routename="post_stats"] main.main > div {
+									margin-top: 0;
 								}
 								shreddit-app[routename="post_page"] div[slot="post-insights-panel"] .p-md,
 								shreddit-app[routename="comments_page"] div[slot="post-insights-panel"] .p-md,

--- a/src-webpack/src/common/content/tweaks/font/resize_font.js
+++ b/src-webpack/src/common/content/tweaks/font/resize_font.js
@@ -124,11 +124,11 @@ export function postContentFontSize(value) {
 
 // Resize "Post Comments" Font
 export function postCommentsFontSize(value) {
-	if (value != '9' && value != false) {
+	if (value !== '9' && value !== false) {
 		if (redditVersion === 'old') {
 			if (!document.querySelector('style[id="re-post-comment-font-size"]')) {
 				const styleElement = document.createElement('style');
-				styleElement.id = 're-styles';
+				styleElement.id = 're-post-comment-font-size';
 				styleElement.textContent = `.commentarea .thing[data-type="comment"] .usertext p {
 												font-size: var(--re-post-comments-font-size);
 												line-height: 1.4;
@@ -138,7 +138,7 @@ export function postCommentsFontSize(value) {
 		} else if (redditVersion === 'new') {
 			if (!document.querySelector('style[id="re-post-comment-font-size"]')) {
 				const styleElement = document.createElement('style');
-				styleElement.id = 're-styles';
+				styleElement.id = 're-post-comment-font-size';
 				styleElement.textContent = `.Comment [data-testid="comment"] > div,
 				 							.Comment [data-testid="comment"] > div code,
 				 							div[data-test-id="comment-submission-form-richtext"] div.public-DraftEditor-content[contenteditable],
@@ -161,7 +161,7 @@ export function postCommentsFontSize(value) {
 		} else if (redditVersion === 'newnew') {
 			if (!document.querySelector('style[id="re-post-comment-font-size"]')) {
 				const styleElement = document.createElement('style');
-				styleElement.id = 're-styles';
+				styleElement.id = 're-post-comment-font-size';
 				styleElement.textContent = `shreddit-comment div.md[slot="comment"],
 											shreddit-profile-comment div.md,
 											shreddit-composer div[contenteditable] {

--- a/src-webpack/src/common/content/tweaks/hide_elements/hide_side_menu.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/hide_side_menu.js
@@ -75,8 +75,9 @@ function enableHideSideMenuNewNew() {
 										position: static !important;
 									}
 									@media (min-width: 1200px) {
-										shreddit-app .grid-container {
-											grid-template-columns: 0 1fr !important;
+										div.grid-container:not(.grid-full), 
+										div.grid-container:not(.grid-full).flex-nav-expanded {
+											--flex-nav-width: 0;
 										}
 									}`;
 		document.head.insertBefore(styleElement, document.head.firstChild);

--- a/src-webpack/src/common/content/tweaks/hide_elements/hide_side_menu_sections.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/hide_side_menu_sections.js
@@ -143,7 +143,9 @@ function enableHideSideMenuRecentSection() {
 		const styleElement = document.createElement('style');
 		styleElement.id = 're-hide-side-menu-recent-section';
 		styleElement.textContent = `shreddit-app reddit-sidebar-nav reddit-recent-pages,
-									shreddit-app reddit-sidebar-nav reddit-recent-pages + hr {
+									shreddit-app reddit-sidebar-nav reddit-recent-pages + hr,
+									shreddit-app reddit-sidebar-nav faceplate-loader[name*="LeftNavRecentCommunities_"],
+									shreddit-app reddit-sidebar-nav left-nav-recent-communities {
 										display: none !important;
 									}`;
 		document.head.insertBefore(styleElement, document.head.firstChild);

--- a/src-webpack/src/common/content/tweaks/hide_elements/hide_sidebar.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/hide_sidebar.js
@@ -180,6 +180,13 @@ export function enableHideHomeSidebarNewNew() {
 									shreddit-app[routename="popular"] #right-sidebar-container,
 									shreddit-app[routename="inbox"] #right-sidebar-container {
 										display: none;
+										visibility: hidden;
+									}
+									shreddit-app[routename="frontpage"] .subgrid-container,
+									shreddit-app[routename="all"] .subgrid-container,
+									shreddit-app[routename="popular"] .subgrid-container,
+									shreddit-app[routename="inbox"] .subgrid-container {
+										width: fit-content;
 									}
 									shreddit-app[routename="frontpage"] .main-container,
 									shreddit-app[routename="all"] .main-container,
@@ -252,12 +259,10 @@ export function enableHideSubSidebarNewNew() {
 	if (!document.head.querySelector('style[id="re-hide-sub-sidebar"]')) {
 		const styleElement = document.createElement('style');
 		styleElement.id = 're-hide-sub-sidebar';
-		styleElement.textContent = `#right-sidebar-container:has([router-name="subreddit"]),
-									shreddit-app[pagetype="custom_feed"] #right-sidebar-container {
+		styleElement.textContent = `#right-sidebar-container:has([router-name="subreddit"]) {
 										display: none !important;
 									}
-									shreddit-app[routename="subreddit"] .main-container,
-									shreddit-app[pagetype="custom_feed"] .main-container {
+									shreddit-app[routename="subreddit"] .main-container {
 										grid-gap: 0 !important;
 									}`;
 		document.head.insertBefore(styleElement, document.head.firstChild);
@@ -331,8 +336,15 @@ function enableHidePostSidebarNewNew() {
 									}
 									#right-sidebar-container:has([router-name="post_page"]),
 									[routename="profile_post_page"] #right-sidebar-container,
-									[routename="comments_page"] #right-sidebar-container {
+									[routename="comments_page"] #right-sidebar-container,
+									[routename="post_stats"] #right-sidebar-container {
 										display: none !important;
+									}
+									shreddit-app[routename="post_page"] .subgrid-container,
+									shreddit-app[routename="profile_post_page"] .subgrid-container,
+									shreddit-app[routename="comments_page"] .subgrid-container,
+									shreddit-app[routename="post_stats"] .subgrid-container {
+										width: fit-content
 									}
 									shreddit-app[routename="post_page"] #main-content.grid,
 									shreddit-app[routename="profile_post_page"] #main-content.grid,
@@ -460,6 +472,9 @@ export function enableHideUserSidebarNewNew() {
 		styleElement.textContent = `#right-sidebar-container:has([source="profile"]) {
 										display: none !important;
 									}
+									shreddit-app[routename*="profile_"] .subgrid-container {
+										width: fit-content;
+									}
 									shreddit-app[routename="profile_post_page"] .main-container,
 									shreddit-app[routename="profile_overview"] .main-container,
 									shreddit-app[routename="profile_posts"] .main-container,
@@ -557,6 +572,9 @@ export function enableHideSearchSidebarNewNew() {
 		styleElement.textContent = `[pagetype="search_results"] #right-sidebar-container {
 										display: none !important;
 									}
+									shreddit-app[pagetype="search_results"] .subgrid-container {
+										width: fit-content;
+									}
 									shreddit-app[pagetype="search_results"] .main-container {
 										grid-gap: 0 !important;
 									}`;
@@ -606,11 +624,11 @@ function enableHideCustomFeedSidebarNewNew() {
 										display: none;
 										visibility: hidden;
 									}
+									shreddit-app[routename="custom_feed"] .subgrid-container {
+										width: fit-content;
+									}
 									shreddit-app[routename="custom_feed"] div.main-container {
 										gap: 0;
-									}
-									shreddit-app[routename="custom_feed"] main.main {
-										max-width: 100% !important;
 									}
 									:root {
 										--re-custom-feed-sidebar-width: 0 !important;

--- a/src-webpack/src/common/content/tweaks/hide_elements/side_menu_toggle_button.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/side_menu_toggle_button.js
@@ -77,6 +77,11 @@ function enableSideMenuToggleButton() {
 									[data-re-hide-side-menu="true"] {
 										--re-side-menu-width: 0;
 									}
+									@media (min-width: 1200px) {
+										[data-re-hide-side-menu="true"] .grid-container:not(.grid-full) {
+											--flex-nav-width: 0;
+										}
+									}
 									shreddit-app[data-re-hide-side-menu="true"] #left-sidebar-container {
 										display: none !important;
 									}

--- a/src-webpack/src/common/content/tweaks/hide_elements/side_menu_toggle_button.js
+++ b/src-webpack/src/common/content/tweaks/hide_elements/side_menu_toggle_button.js
@@ -74,13 +74,9 @@ function enableSideMenuToggleButton() {
 										--re-hide-side-menu-gap-multiplyer: 1;
 										--re-hide-side-menu-gap-multiplyer2: 1;
 									}
+									/* For functions relying on RE's own CSS variable */
 									[data-re-hide-side-menu="true"] {
 										--re-side-menu-width: 0;
-									}
-									@media (min-width: 1200px) {
-										[data-re-hide-side-menu="true"] .grid-container:not(.grid-full) {
-											--flex-nav-width: 0;
-										}
 									}
 									shreddit-app[data-re-hide-side-menu="true"] #left-sidebar-container {
 										display: none !important;
@@ -88,13 +84,13 @@ function enableSideMenuToggleButton() {
 									shreddit-app[data-re-hide-side-menu="false"] #left-sidebar-container {
 										z-index: 1;
 									}
+									@media (min-width: 1200px) {
+										[data-re-hide-side-menu="true"] .grid-container:not(.grid-full) {
+											--flex-nav-width: 0;
+										}
+									}
 									pdp-back-button {
 										position: static !important;
-									}
-									@media (min-width: 1200px) {
-										shreddit-app[data-re-hide-side-menu="true"] .grid-container {
-											grid-template-columns: 0 1fr !important;
-										}
 									}
 									.re-side-menu-close,
 									.re-side-menu-open {

--- a/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
@@ -269,224 +269,101 @@ function disableExpandContentNew() {
 function enableExpandContentNewNew() {
 	const styleElement = document.createElement('style');
 	styleElement.id = 're-expand-feed-layout';
-	styleElement.textContent = `:root {
-									--re-side-menu-width: 272px;								
-									--re-home-sidebar-width: 316px;
-									--re-post-sidebar-width: 316px;
-									--re-search-sidebar-width: 316px;
-									--re-sub-sidebar-width: 316px;
-									--re-user-profile-sidebar-width: 316px;
-									--re-custom-feed-sidebar-width: 316px;
-								}
-
-								/* @media (min-width: 768px) {
-									shreddit-app[routename="frontpage"] .main-container {
-										margin-right: 2rem !important;
-									}
-								} */
-
-								@media (max-width: 768px) {
-									shreddit-app[routename="subreddit"] .subgrid-container {
-										margin-right: 0;
-									}
-								}
-
-								@media (min-width: 960px) {
-									.subgrid-container {
-										width: 100% !important;
-									}
-								}
-
-								@media (max-width: 959px) {
-									.main-container {
-										grid-template-columns: auto !important;
-										--re-sub-sidebar-width: 0 !important;
-									}
-								}
-
-								@media (max-width: 770px) {
-									.main-container {
-										--re-home-sidebar-width: 0 !important;
-										--re-post-sidebar-width: 0 !important;
-										--re-search-sidebar-width: 0 !important;
-										--re-user-profile-sidebar-width: 0 !important;
-									}
-									#right-sidebar-container {
-										display: none !important;
-									}
-								}
-
-								@media (max-width: 1200px) {
-									.subgrid-container {
-										--re-side-menu-width: 0 !important;
-									}
-								}
-
-								@media (min-width: 1200px) {
-									.m\\:grid-cols-\\[272px_1fr\\] {
-										grid-template-columns: var(--re-side-menu-width) 1fr !important;
-									}
-									.grid-container:not(.grid-full) {
-										grid-template-columns: var(--re-side-menu-width) 1fr !important;;
-									}
-								}
-								
-								shreddit-app[routename="frontpage"] #main-content,
-								shreddit-app[routename="all"] #main-content,
-								shreddit-app[routename="popular"] #main-content,
-								shreddit-app[pagetype="search_results"] #main-content,
-								shreddit-app[pagetype="post_submit"] #main-content,
-								shreddit-app[routename="frontpage"] main.main,
-								shreddit-app[routename="all"] main.main,
-								shreddit-app[routename="popular"] main.main,
-								shreddit-app[pagetype="search_results"] main.main,
-								shreddit-app[pagetype="post_submit"] main.main{
-									width: var(--re-content-width) !important;
-									min-width: var(--re-content-width) !important;
-									justify-self: center;
-									margin-left: 0;
-								}
-								shreddit-app[routename="inbox"] #main-content,
-								shreddit-app[routename="inbox"] main.main {
-									max-width: var(--re-content-width) !important;
-									justify-self: center;
-								}
-								shreddit-app[pagetype="search_results"] #main-content,
-								shreddit-app[pagetype="search_results"] main.main {
-									max-width: 100% !important;
-								}
-								shreddit-app[routename="subreddit"] #main-content,
-								shreddit-app[routename="subreddit"] main.main,
-								shreddit-app[routename="subreddit_wiki"] #main-content,
-								shreddit-app[routename="subreddit_wiki"] main.main {
-									width: var(--re-sub-width);
-									max-width: 100%;
-									justify-self: center;
-								}
-								shreddit-app[routename="post_page"] #main-content,
-								shreddit-app[routename="comments_page"] #main-content,
-								shreddit-app[routename="profile_post_page"] #main-content,
-								shreddit-app[routename="post_page"] main.main,
-								shreddit-app[routename="comments_page"] main.main,
-								shreddit-app[routename="profile_post_page"] main.main {
-									max-width: var(--re-post-width) !important;
-									justify-self: center;
-								}
-								shreddit-app[routename="profile_overview"] #main-content,
-								shreddit-app[routename="profile_posts"] #main-content,
-								shreddit-app[routename="profile_comments"] #main-content,
-								shreddit-app[routename="profile_saved"] #main-content,
-								shreddit-app[routename="profile_hidden"] #main-content,
-								shreddit-app[routename="profile_upvoted"] #main-content,
-								shreddit-app[routename="profile_downvoted"] #main-content,
-								shreddit-app[routename="profile_overview"] main.main,
-								shreddit-app[routename="profile_posts"] main.main,
-								shreddit-app[routename="profile_comments"] main.main,
-								shreddit-app[routename="profile_saved"] main.main,
-								shreddit-app[routename="profile_hidden"] main.main,
-								shreddit-app[routename="profile_upvoted"] main.main,
-								shreddit-app[routename="profile_downvoted"] main.main{
-									width: var(--re-user-profile-width) !important;
-									min-width: var(--re-user-profile-width) !important;
-									justify-self: center;
-								}
-								shreddit-app[routename="topic"] #main-content,
-								shreddit-app[routename="topic"] main.main {
-									min-width: var(--re-topic-feed-width) !important;
-									max-width: var(--re-topic-feed-width) !important;
-									justify-self: center;
-								}
-
-								/*shreddit-app .grid-container {
-									grid-template-columns: var(--re-side-menu-width) auto;
-								} */
-								shreddit-app[routename="frontpage"] .subgrid-container,
-								shreddit-app[routename="subreddit"] .subgrid-container,
-								shreddit-app[routename="post_page"] .subgrid-container,
-								shreddit-app[routename="comments_page"] .subgrid-container,
-								shreddit-app[routename="profile_post_page"] .subgrid-container,
-								shreddit-app[routename="profile_overview"] .subgrid-container,
-								shreddit-app[routename="profile_posts"] .subgrid-container,
-								shreddit-app[routename="profile_comments"] .subgrid-container,
-								shreddit-app[routename="profile_saved"] .subgrid-container,
-								shreddit-app[routename="profile_hidden"] .subgrid-container,
-								shreddit-app[routename="profile_upvoted"] .subgrid-container,
-								shreddit-app[routename="profile_downvoted"] .subgrid-container,
-								shreddit-app[routename="all"] .subgrid-container,
-								shreddit-app[routename="popular"] .subgrid-container,
-								shreddit-app[pagetype="search_results"] .subgrid-container,
-								shreddit-app[routename="explore-page"] .subgrid-container,
-								shreddit-app[pagetype="post_submit"] .subgrid-container,
-								shreddit-app[pagetype="custom_feed"] .subgrid-container {
-									/*width: 100% !important;
-									min-width: calc(100vw - var(--re-side-menu-width)) !important;
-									max-width: calc(100vw - var(--re-side-menu-width)) !important; */
-									--flex-nav-width: var(--re-side-menu-width);
-								}
-								div.masthead shreddit-gallery-carousel {
-									max-width: calc(100vw - 2rem);
-								}
-
-								shreddit-app[routename="frontpage"] .main-container, 
-								shreddit-app[routename="all"] .main-container,
-								shreddit-app[routename="popular"] .main-container,
-								shreddit-app[routename="topic"] .main-container,
-								shreddit-app[routename="inbox"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-home-sidebar-width) !important;
-								}
-
-								shreddit-app[pagetype="search_results"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-search-sidebar-width) !important;
-								}
-
-								shreddit-app[routename="subreddit"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-sub-sidebar-width) !important;
-								}
-
-								shreddit-app[routename="subreddit_wiki"] .main-container,
-								shreddit-app[pagetype="post_submit"] .main-container {
-									display: grid;
-									grid-template-columns: auto 316px;
-								}
-
-								shreddit-app[routename="profile_overview"] .main-container,
-								shreddit-app[routename="profile_posts"] .main-container,
-								shreddit-app[routename="profile_comments"] .main-container,
-								shreddit-app[routename="profile_saved"] .main-container,
-								shreddit-app[routename="profile_hidden"] .main-container,
-								shreddit-app[routename="profile_upvoted"] .main-container,
-								shreddit-app[routename="profile_downvoted"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-user-profile-sidebar-width) !important;
-								}
-								
-								shreddit-app[routename="post_page"] .main-container,
-								shreddit-app[routename="comments_page"] .main-container,
-								shreddit-app[routename="profile_post_page"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-post-sidebar-width) !important;
-								}
-
-								shreddit-app[pagetype="custom_feed"] .main-container {
-									display: grid;
-									grid-template-columns: auto var(--re-custom-feed-sidebar-width) !important;
-									/*min-width: var(--re-main-container-width, 100%);
-									max-width: calc(100% - var(--re-side-menu-width));*/
-								}
-
-								shreddit-app[pagetype="custom_feed"] #main-content,
-								shreddit-app[pagetype="custom_feed"] main.main {
-									min-width: var(--re-custom-feed-width) !important;
-									max-width: var(--re-custom-feed-width) !important;
-									justify-self: center;
-								}
-									
-								/*shreddit-app[routename="explore-page"] .main-container {
-									width: calc(100vw - 2rem) !important;
-								}*/`;
+	styleElement.textContent =
+		`
+		.grid-container:not(.grid-full) div#subgrid-container {
+			width: 100%;
+		}
+		shreddit-app[routename="frontpage"] .main-container, 
+		shreddit-app[routename="all"] .main-container,
+		shreddit-app[routename="popular"] .main-container,
+		shreddit-app[routename="topic"] .main-container,
+		shreddit-app[routename="inbox"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-home-sidebar-width, 316px);
+		}
+		shreddit-app[pagetype="search_results"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-search-sidebar-width, 316px);
+		}
+		shreddit-app[routename="subreddit"] .main-container,
+		shreddit-app[routename="subreddit_wiki"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-sub-sidebar-width, 316px);
+		}
+		shreddit-app[routename="post_page"] .main-container,
+		shreddit-app[routename="comments_page"] .main-container,
+		shreddit-app[routename="profile_post_page"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-post-sidebar-width, 316px);
+		}
+		shreddit-app[routename="profile_overview"] .main-container,
+		shreddit-app[routename="profile_posts"] .main-container,
+		shreddit-app[routename="profile_comments"] .main-container,
+		shreddit-app[routename="profile_saved"] .main-container,
+		shreddit-app[routename="profile_hidden"] .main-container,
+		shreddit-app[routename="profile_upvoted"] .main-container,
+		shreddit-app[routename="profile_downvoted"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-user-profile-sidebar-width, 316px);
+		}
+		shreddit-app[pagetype="custom_feed"] .main-container {
+			display: grid;
+			grid-template-columns: auto var(--re-custom-feed-sidebar-width, 316px);
+		}
+		shreddit-app[pagetype="post_submit"] .main-container {
+			display: grid;
+			grid-template-columns: auto 316px;
+		}
+		shreddit-app[routename="frontpage"] main.main,
+		shreddit-app[routename="all"] main.main,
+		shreddit-app[routename="popular"] main.main,
+		shreddit-app[pagetype="search_results"] main.main,
+		shreddit-app[pagetype="post_submit"] main.main,
+		shreddit-app[routename="inbox"] main.main {
+			max-width: var(--re-content-width);
+			justify-self: center;
+		}
+		div.masthead shreddit-gallery-carousel {
+			max-width: calc(100vw - 2rem);
+		}
+		shreddit-app[routename="subreddit"] main.main,
+		shreddit-app[routename="subreddit_wiki"] main.main {
+			max-width: var(--re-sub-width);
+			justify-self: center;
+		}
+		shreddit-app[routename="post_page"] main.main,
+		shreddit-app[routename="comments_page"] main.main,
+		shreddit-app[routename="profile_post_page"] main.main,
+		shreddit-app[routename="post_stats"] main.main {
+			max-width: var(--re-post-width);
+			justify-self: center;
+		}
+		shreddit-app[routename="profile_overview"] main.main,
+		shreddit-app[routename="profile_posts"] main.main,
+		shreddit-app[routename="profile_comments"] main.main,
+		shreddit-app[routename="profile_saved"] main.main,
+		shreddit-app[routename="profile_hidden"] main.main,
+		shreddit-app[routename="profile_upvoted"] main.main,
+		shreddit-app[routename="profile_downvoted"] main.main {
+			max-width: var(--re-user-profile-width);
+			justify-self: center;
+		}
+		shreddit-app[routename="topic"] main.main {
+			min-width: var(--re-topic-feed-width) !important;
+			max-width: var(--re-topic-feed-width) !important;
+			justify-self: center;
+		}
+		shreddit-app[pagetype="custom_feed"] main.main {
+			max-width: var(--re-custom-feed-width);
+			justify-self: center;
+		}
+		@media (max-width: 959px) {				
+			.main-container {
+				grid-template-columns: auto !important;
+			}
+		}
+		`;
 	document.head.appendChild(styleElement);
 	document.documentElement.classList.add('re-expand-feed-layout');
 }

--- a/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
@@ -318,7 +318,7 @@ function enableExpandContentNewNew() {
 		shreddit-app[routename="frontpage"] main.main,
 		shreddit-app[routename="all"] main.main,
 		shreddit-app[routename="popular"] main.main,
-		shreddit-app[routename="mod_queue_all"] div[slot="mod-queue-feed"] > div,
+		shreddit-app[routename="mod_queue_all"] div[slot="mod-queue-feed"] > div.max-w-\\[756px\\],
 		shreddit-app[pagetype="search_results"] main.main,
 		shreddit-app[pagetype="post_submit"] main.main,
 		shreddit-app[routename="inbox"] main.main {
@@ -329,7 +329,8 @@ function enableExpandContentNewNew() {
 			max-width: calc(100vw - 2rem);
 		}
 		shreddit-app[routename="subreddit"] main.main,
-		shreddit-app[routename="subreddit_wiki"] main.main {
+		shreddit-app[routename="subreddit_wiki"] main.main,
+		shreddit-app[routename="mod_queue"] div[slot="mod-queue-feed"] > div.max-w-\\[756px\\] {
 			max-width: var(--re-sub-width);
 			justify-self: center;
 		}

--- a/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/expand_content.js
@@ -318,6 +318,7 @@ function enableExpandContentNewNew() {
 		shreddit-app[routename="frontpage"] main.main,
 		shreddit-app[routename="all"] main.main,
 		shreddit-app[routename="popular"] main.main,
+		shreddit-app[routename="mod_queue_all"] div[slot="mod-queue-feed"] > div,
 		shreddit-app[pagetype="search_results"] main.main,
 		shreddit-app[pagetype="post_submit"] main.main,
 		shreddit-app[routename="inbox"] main.main {

--- a/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
@@ -36,7 +36,8 @@ function enableResizeMainContainer() {
 		@media (min-width: 960px) {
             div.main-container,
             div.masthead shreddit-gallery-carousel,
-            [pagetype="search_results"] div.masthead {
+            [pagetype="search_results"] div.masthead,
+            mod-queue-app {
                 width: var(--re-main-container-width, 80%) !important;
                 margin: 0 auto;
             }

--- a/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
@@ -31,10 +31,13 @@ export function resizeMainContainer(value) {
 function enableResizeMainContainer() {
 	const styleElement = document.createElement('style');
 	styleElement.id = 're-resize-main-container';
-	styleElement.textContent = `@media (min-width: 960px) {
+	styleElement.textContent =
+		`
+		@media (min-width: 960px) {
             div.main-container,
-            div.masthead shreddit-gallery-carousel {
-                width: var(--re-main-container-width) !important;
+            div.masthead shreddit-gallery-carousel,
+            [pagetype="search_results"] div.masthead {
+                width: var(--re-main-container-width, 80%) !important;
                 margin: 0 auto;
             }
             /* Align subreddit title with main-content */
@@ -43,13 +46,14 @@ function enableResizeMainContainer() {
             }
             div.masthead > section,
             div.masthead:has(> custom-feed-header) {
-                width: var(--re-main-container-width);
+                width: var(--re-main-container-width, 80%);
                 margin: 0 auto;
             }
             community-appearance-entrypoint[target="banner"] {
                 margin-bottom: 3rem !important;
             }
-        }`;
+        }
+        `;
 	document.head.insertBefore(styleElement, document.head.firstChild);
 }
 

--- a/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/resize_main_container.js
@@ -36,8 +36,7 @@ function enableResizeMainContainer() {
 		@media (min-width: 960px) {
             div.main-container,
             div.masthead shreddit-gallery-carousel,
-            [pagetype="search_results"] div.masthead,
-            mod-queue-app {
+            [pagetype="search_results"] div.masthead {
                 width: var(--re-main-container-width, 80%) !important;
                 margin: 0 auto;
             }

--- a/src-webpack/src/common/content/tweaks/resize_elements/side_menu_width.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/side_menu_width.js
@@ -31,7 +31,13 @@ function enableSideMenuWidth() {
 	if (!document.querySelector('style[id="re-side-menu-width"]')) {
 		const styleElement = document.createElement('style');
 		styleElement.id = 're-side-menu-width';
-		styleElement.textContent = `#left-sidebar-container {
+		styleElement.textContent = `@media (min-width: 1200px) {
+										.grid-container:not(.grid-full), 
+										.grid-container:not(.grid-full).flex-nav-expanded {
+											--flex-nav-width: var(--re-side-menu-width) !important;
+										}
+									}`;
+									/*`#left-sidebar-container {
 										max-width: var(--re-side-menu-width) !important;
 									}
 									@media (min-width: 1200px) {
@@ -48,7 +54,7 @@ function enableSideMenuWidth() {
 										.m\\:grid-cols-\\[272px_1fr\\] {
 											grid-template-columns: var(--re-side-menu-width) 1fr !important;
 										}
-									}`;
+									}`; */
 		document.head.insertBefore(styleElement, document.head.firstChild);
 	}
 }

--- a/src-webpack/src/common/content/tweaks/resize_elements/side_menu_width.js
+++ b/src-webpack/src/common/content/tweaks/resize_elements/side_menu_width.js
@@ -32,29 +32,11 @@ function enableSideMenuWidth() {
 		const styleElement = document.createElement('style');
 		styleElement.id = 're-side-menu-width';
 		styleElement.textContent = `@media (min-width: 1200px) {
-										.grid-container:not(.grid-full), 
-										.grid-container:not(.grid-full).flex-nav-expanded {
-											--flex-nav-width: var(--re-side-menu-width) !important;
+										div.grid-container:not(.grid-full), 
+										div.grid-container:not(.grid-full).flex-nav-expanded {
+											--flex-nav-width: var(--re-side-menu-width);
 										}
 									}`;
-									/*`#left-sidebar-container {
-										max-width: var(--re-side-menu-width) !important;
-									}
-									@media (min-width: 1200px) {
-										.grid-container {
-											grid-template-columns: var(--re-side-menu-width) 1fr !important;
-										}
-									}
-									@media (min-width: 1200px) {
-										.m\\:max-w-\\[calc\\(100vw-272px\\)\\] {
-											max-width: calc(100vw - var(--re-side-menu-width)) !important;
-										}
-									}
-									@media (min-width: 1200px) {
-										.m\\:grid-cols-\\[272px_1fr\\] {
-											grid-template-columns: var(--re-side-menu-width) 1fr !important;
-										}
-									}`; */
 		document.head.insertBefore(styleElement, document.head.firstChild);
 	}
 }

--- a/src-webpack/src/common/content/tweaks/style/border_radius.js
+++ b/src-webpack/src/common/content/tweaks/style/border_radius.js
@@ -52,6 +52,7 @@ function addBorderRadiusAmountStylesheet() {
 			div#right-sidebar-container aside,
 			div#right-sidebar-container aside a,
 			div#right-sidebar-container aside button,
+			div#right-sidebar-container [data-testid="search-results-sidebar"],
 			/* Post media previews */
 			div[slot="thumbnail"],
 			div[slot="post-media-container"],


### PR DESCRIPTION
I'll include the changelog of older PRs here as well:

```
* Added options to fade text previews of Card posts, and to adjust the fade position and height of the text preview (experimental)
* Fixed an issue where post images won't show when Hide the Header Bar is on
* Fixed an issue with Hide the Recent Subreddit section in the side menu, as Reddit changed its name to Recently Visited
* Fixed an issue where resizing comment text is not persistent
* Fixed an issue where opening the side menu may cause custom feeds to shrink when Hide the Custom Feed sidebar is on
* Fixed issues where Show Post Flairs may not add flairs with no rich formatting and may attach flairs twice in rare cases
* Resize Feed / Post, Font: Post Title and Custom Background should now also apply to profile posts
* Post: Title and Text Content Colour should now also colour h1, pre elements and text in tables
* Side Menu Width, Hide the Side Menu & Side Menu Toggle Button now uses Reddit's native CSS variables to adjust its width
* Post Background should now also apply to Compact posts in moderation queue, and the new Post Insights page
* Resize Feed / Post should now apply to global and subreddit mod queue
* Disabled Custom Background on subreddit moderation pages — there's little we can do about them
* Centre feeds when sidebars are hidden (see #131). It is possible to replicate the older behaviour with Feed Offsets
* Rewrote and optimised the CSS code for Resize Feed / Post
* Small styling tweaks to make blockquotes more compact
```

re: side menu, Reddit already set `grid-template-columns: var(--flex-nav-width) 1fr` on `.grid-container` so it's best we only manipulate the `--flex-nav-width` variable, rather than creating our own.

Closes #131. I'll leave you some room to address other bugs and/or probably add some features.