### PR TITLE
fix(i18n): prevent untranslated popup flash

### DIFF
--- a/src-webpack/src/common/popup/css/base.css
+++ b/src-webpack/src/common/popup/css/base.css
@@ -45,3 +45,9 @@ h3 {
 	color: var(--text-grey);
 	text-wrap-mode: nowrap;
 }
+/* Keep the popup out of the paint tree until its locale has been applied.
+ * Theme restoration may reveal the body first, so this separate class prevents
+ * empty data-lang elements and English fallback labels from flashing onscreen. */
+body.i18n-pending {
+	visibility: hidden;
+}

--- a/src-webpack/src/common/popup/popup.hbs
+++ b/src-webpack/src/common/popup/popup.hbs
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="stylesheet" href="popup.css" />
 	</head>
-	<body id="popup" class="theme-dark" style="display: none">
+	<body id="popup" class="theme-dark i18n-pending" style="display: none">
 		<!-- = Title = -->
 		<div class="menu-title-container">
 			<span class="menu-title">

--- a/src-webpack/src/common/popup/popup_internationalisation.js
+++ b/src-webpack/src/common/popup/popup_internationalisation.js
@@ -3,7 +3,16 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import i18next from 'i18next';
-import HttpBackend from 'i18next-http-backend';
+
+// Bundle every locale into the popup so first paint never waits for an
+// extension-URL fetch. require.context keeps the language list in one place:
+// adding a new _locales/<lang>/messages.json file automatically includes it.
+const localeContext = require.context('../_locales', true, /messages\.json$/);
+const localeResources = localeContext.keys().reduce((resources, localePath) => {
+	const match = localePath.match(/^\.\/([^/]+)\/messages\.json$/);
+	if (match) resources[match[1]] = { translation: localeContext(localePath) };
+	return resources;
+}, {});
 
 // Load Language From Save
 BROWSER_API.storage.sync.get(['language'], function (result) {
@@ -26,18 +35,28 @@ BROWSER_API.storage.sync.get(['language'], function (result) {
 
 // Init Internationalisation
 export function init_i18n(lang) {
-	i18next
-		.use(HttpBackend)
-		.init({
-			lng: lang,
-			fallbackLng: 'en',
-			backend: {
-				loadPath: '/_locales/{{lng}}/messages.json',
-			},
-		})
-		.then(() => {
-			translate();
-		});
+	try {
+		if (i18next.isInitialized) {
+			// All resources are already in memory, so this updates synchronously.
+			i18next.changeLanguage(lang);
+		} else {
+			i18next.init({
+				lng: lang,
+				fallbackLng: 'en',
+				resources: localeResources,
+				initAsync: false,
+			});
+		}
+
+		translate();
+		document.documentElement.lang = lang.replace('_', '-');
+	} catch (error) {
+		console.error('Failed to initialise popup translations:', error);
+	} finally {
+		// Translation and theme restoration can finish in either order. Removing
+		// this class only after translate() makes the first visible frame complete.
+		document.body.classList.remove('i18n-pending');
+	}
 }
 
 // Translate based on selected language


### PR DESCRIPTION
## What changed

- bundle the existing locale JSON resources into the popup
- initialise i18next synchronously from those in-memory resources
- keep the popup hidden with an `i18n-pending` class until translation finishes

## Why

The popup can be revealed by theme restoration before `i18next-http-backend` finishes loading the selected locale. In Simplified Chinese this produced an intermediate screen with empty labels and a few English fallbacks such as "Select" and "Off"; the complete Chinese UI appeared only after a delay.

## Benefit for Simplified Chinese

The complete Chinese popup is now ready on its first visible frame, without a blank or mixed English/Chinese flash. Bundling via `require.context` also means a future locale, including the Simplified Chinese locale proposed in #288, is picked up automatically.

## Trade-off and maintainer choice

This is intentionally separate from #288 so the localisation can be merged independently. The trade-off is bundle size: in the Chromium production build, minified `popup.js` grows from 452,238 bytes to 889,708 bytes (about +427 KiB) because all 18 current locales are included.

Please feel free to accept, adapt, or decline this implementation depending on whether the first-paint improvement is worth that cost. An alternative would be to retain asynchronous locale loading and use only the pending-visibility guard, at the cost of keeping the popup hidden while the locale request completes.

## Validation

- Chromium Manifest V3 production build passes
- built output contains the first-paint guard and no runtime locale URL
- tested repeatedly in the locally loaded Chrome extension; the delayed/partial Chinese popup no longer occurs
